### PR TITLE
add rust-vmm to project list

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ List of awesome resources about microVM included blogs, videos, projects and etc
 
 ## Projects
 
+- [rust-vmm](https://github.com/rust-vmm) - Shared Rust crates powering Firecracker and other VMMs.
 - [firecracker](https://github.com/firecracker-microvm/firecracker) - Secure and fast microVMs for serverless computing.
 - [firecracker-containerd](https://github.com/firecracker-microvm/firecracker-containerd) - Enables containerd to manage containers as Firecracker microVMs.
 - [firecracker-task-driver](https://github.com/cneira/firecracker-task-driver) - Nomad task driver that uses firecracker to start micro-vms.


### PR DESCRIPTION
This PR adds a link to rust-vmm under the Projects section. It provides reusable Rust crates used by Firecracker, Cloud Hypervisor, and other VMMs, and is a key resource for those interested in contributing to the microVM ecosystem.