### PR TITLE
Add mitos (live CoW fork of Firecracker microVMs)

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ List of awesome resources about microVM included blogs, videos, projects and etc
 - [KubeFire](https://github.com/innobead/kubefire) - Creates and manages Kubernetes Clusters using Firecracker microVMs.
 - [Hyperlight](https://github.com/hyperlight-dev/hyperlight) - A lightweight Virtual Machine Manager (VMM) designed to be embedded within applications.
 - [firecracker-in-docker](https://github.com/fadams/firecracker-in-docker) - A proof of concept project to run Firecracker MicroVMs inside unprivileged Docker containers.
+- [mitos](https://github.com/mitos-run/mitos) - Kubernetes-native runtime that live copy-on-write forks a running Firecracker microVM into N isolated, self-hostable sandboxes for AI agents.
 
 ## SDK
 


### PR DESCRIPTION
Adds [mitos](https://github.com/mitos-run/mitos) to Projects: an open-source (Apache-2.0), Kubernetes-native runtime that does N-way live copy-on-write fork of a *running* Firecracker microVM into independent sandboxes, aimed at AI agents. Self-hostable; standalone REST server and Python/TypeScript SDKs available. Thanks for the list!